### PR TITLE
solved problem unable to load gazebo_controller pid_gains

### DIFF
--- a/turtlebot3_home_service_challenge_simulation/config/gazebo_controller.yaml
+++ b/turtlebot3_home_service_challenge_simulation/config/gazebo_controller.yaml
@@ -1,0 +1,11 @@
+/tb3_hsc/gazebo_ros_control:
+  pid_gains:
+    joint1: {p: 300.0, i: 0.1, d: 1.0, i_clamp: 0.2}
+    joint2: {p: 300.0, i: 0.1, d: 1.0, i_clamp: 0.2}
+    joint3: {p: 300.0, i: 0.1, d: 1.0, i_clamp: 0.2}
+    joint4: {p: 300.0, i: 0.1, d: 1.0, i_clamp: 0.2}
+
+gazebo_ros_control:
+  pid_gains:
+    gripper_sub: {p: 300.0, i: 0.1, d: 1.0, i_clamp: 0.2}
+    

--- a/turtlebot3_home_service_challenge_simulation/launch/world/competition.launch
+++ b/turtlebot3_home_service_challenge_simulation/launch/world/competition.launch
@@ -10,7 +10,7 @@
   <arg name="debug" default="false"/>
   <arg name="verbose" default="false"/>
 
-  <rosparam file="$(find turtlebot3_manipulation_gazebo)/config/gazebo_controller.yaml" command="load" />
+  <rosparam file="$(find turtlebot3_home_service_challenge_simulation)/config/gazebo_controller.yaml" command="load" />
   
   <!-- We resume the logic in empty_world.launch, changing only the name of the world to be launched -->
   <include file="$(find gazebo_ros)/launch/empty_world.launch">


### PR DESCRIPTION
Hi. I am a big fan of turtlebot3 and currently working on a graduate school project.
I sent an email few days ago about the gripper slipping problem in gazebo environment.
Recently, I solved a problem so I pull a request.

The problem was, pid gain of arm joint 1,2,3,4 was missing when running the launch file turtlebot3_home_service_challenge_simulation competition.launch
It was due to there was no namespace designation in the turtlebot_manipulation_simulations/turtlebot3_manipulation_gazebo/config/gazebo_controller.yaml file.

So I added new configuration file about gazebo_controller in turtlebot3_home_service_challenge_simualtion directory and added namespace tb3_hsc for joint 1,2,3,4.
After gazebo_controller runs normally, there was no slipping problem when grasping object in gazebo.
Hope this pull request can help improve this package and other users.
Thank you for reading :)
